### PR TITLE
Automate backups for squash-db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,9 @@ LOCAL_VOLUME_CONFIG = kubernetes/local_volume.yaml
 PERSISTENT_VOLUME_CLAIM_CONFIG = kubernetes/persistent_volume_claim.yaml
 DEPLOYMENT_CONFIG = kubernetes/deployment.yaml
 SERVICE_CONFIG = kubernetes/service.yaml
+DB_BACKUP_CONFIG = kubernetes/squash-db-backup.yaml
 
-secret: $(MYSQL_PASSWD)
+mysql-secret: $(MYSQL_PASSWD)
 	@echo "Creating secret for squash-db password..."
 	kubectl delete --ignore-not-found=true secrets mysql-passwd
 	kubectl create secret generic mysql-passwd --from-file=$(MYSQL_PASSWD)
@@ -21,7 +22,7 @@ service:
 	kubectl delete --ignore-not-found=true services squash-db
 	kubectl create -f $(SERVICE_CONFIG)
 
-deployment: service secret configmap
+deployment: service mysql-secret configmap
 	@echo "Creating deployment..."
 
 	kubectl delete --ignore-not-found=true PersistentVolume mysql-volume-1
@@ -36,6 +37,41 @@ deployment: service secret configmap
 	kubectl delete --ignore-not-found=true deployment squash-db
 	kubectl create -f $(DEPLOYMENT_CONFIG)
 
+backup-secret: check-aws-creds check-s3-bucket check-slack-webhook
+	@echo "Creating backup secret"
+	kubectl delete --ignore-not-found=true secrets squash-db-backup
+	kubectl create secret generic squash-db-backup \
+        --from-literal=AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
+        --from-literal=AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
+        --from-literal=S3_BUCKET=${S3_BUCKET} \
+        --from-literal=SLACK_WEBHOOK=${SLACK_WEBHOOK}
+
+squash-db-backup:  backup-secret
+	@echo "Schedule periodic backups for squash-db"
+	kubectl delete --ignore-not-found=true cronjob squash-db-backup
+	kubectl create -f $(DB_BACKUP_CONFIG)
+
+check-aws-creds:
+	@if [ -z ${AWS_ACCESS_KEY_ID} ]; \
+	then echo "Error: AWS_ACCESS_KEY_ID is undefined."; \
+       exit 1; \
+    fi
+	@if [ -z ${AWS_SECRET_ACCESS_KEY} ]; \
+    then echo "Error: AWS_SECRET_ACCESS_KEY is undefined."; \
+       exit 1; \
+    fi
+
+check-s3-bucket:
+	@if [ -z ${S3_BUCKET} ]; \
+	then echo "Error: S3_BUCKET is undefined."; \
+       exit 1; \
+    fi
+
+check-slack-webhook:
+	@if [ -z "${SLACK_WEBHOOK}" ]; \
+	then echo "Error: SLACK_WEBHOOK is undefined."; \
+       exit 1; \
+    fi
 
 clean:
 	rm $(MYSQL_PASSWD)

--- a/README.md
+++ b/README.md
@@ -48,12 +48,50 @@ kubectl exec -it <squash-api pod> -c api /bin/bash
 mysql -hsquash-db -uroot -p<database password>
 ```
 
-## Restoring a copy of SQuaSH's production database
+## Scheduling periodic database backups
 
-For local tests it's useful to restore a copy of the production SQuaSH database. Currently, you can get that from 
-AWS S3 backups (you will need your AWS credentials). We plan to change the database backups to kubernetes, so this
-[will change soon](https://jira.lsstcorp.org/browse/DM-11486).
+For database backups we use [kube-backup](https://github.com/lsst-sqre/kube-backup) which provides a utility container to back up files and databases from other containers.
 
+There's a Kubernetes [Cron Job configuration](https://github.com/lsst-sqre/squash-db/kubernetes/squash-db-backup.yaml) to schedule backup jobs daily. It's meant to work only in the `squash-prod` namespace.  
+In order to create the required secret for `kube-backup` you have to set the following environment variables:
+
+```
+export AWS_ACCESS_KEY_ID=<your AWS credentials>
+export AWS_SECRET_ACCESS_KEY=<your AWS credentials>
+export S3_BUCKET=<the S3 bucket URI to where we want to store the database backups>
+export SLACK_WEBHOOK=<the Slack webhook URL for the #dm-square-status channel>
+```
+
+and then type `make squash_db_backup`.
+
+Output example:
+
+```bash
+
+$ make squash-db-backup
+Creating backup secret
+kubectl delete --ignore-not-found=true secrets squash-db-backup
+secret "squash-db-backup" deleted
+kubectl create secret generic squash-db-backup \
+        --from-literal=AWS_ACCESS_KEY_ID=*******
+        --from-literal=AWS_SECRET_ACCESS_KEY=******* \
+        --from-literal=S3_BUCKET=******* \
+        --from-literal=SLACK_WEBHOOK=******** 
+secret "squash-db-backup" created
+Schedule periodic backups for squash-db
+kubectl delete --ignore-not-found=true cronjob squash-db-backup
+cronjob "squash-db-backup" deleted
+kubectl create -f kubernetes/squash-db-backup.yaml
+cronjob "squash-db-backup" created
+```
+
+## Restoring a copy of the current SQuaSH's production database
+
+
+You can get a copy from the current production database from
+AWS S3 (you will need your AWS credentials). 
+
+Note that this procedure will change once we switch over to the new production deployment, see [DM-11486](https://jira.lsstcorp.org/browse/DM-11486).
 This can be done opening a terminal inside the `squash-db` or `squash-api` pods.
 
 ```
@@ -68,7 +106,6 @@ mysql -uroot -p<passwd> qadb < latest.sql
 # The following is nedeed since the name of the django app changed 
 # from 'dashboard' to 'api' in the current implementation. 
  
-MariaDB [qadb]> rename table dashboard_job to api_job, dashboard_measurement to api_measurement, dashboard_metric to api_metric, dashboard_versionedpackage to api_versionedpackage;
-Query OK, 0 rows affected (0.062 sec)
+mysql -uroot -p<passwd> qadb -e "RENAME TABLE dashboard_job to api_job, dashboard_measurement to api_measurement, dashboard_metric to api_metric, dashboard_versionedpackage to api_versionedpackage"
 
 ```

--- a/README.md
+++ b/README.md
@@ -85,27 +85,19 @@ kubectl create -f kubernetes/squash-db-backup.yaml
 cronjob "squash-db-backup" created
 ```
 
-## Restoring a copy of the current SQuaSH's production database
+## Restoring a copy of the production database
 
-
-You can get a copy from the current production database from
+You can get a backup copy of the current production database from
 AWS S3 (you will need your AWS credentials). 
 
-Note that this procedure will change once we switch over to the new production deployment, see [DM-11486](https://jira.lsstcorp.org/browse/DM-11486).
-This can be done opening a terminal inside the `squash-db` or `squash-api` pods.
-
 ```
-aws s3 cp s3://jenkins-prod-qadb.lsst.codes-backups/qadb/latest.sql.gz .
-gzip -d latest.sql.gz
-
-kubectl cp latest.sql <squash-db pod>:/
+aws s3 ls s3://jenkins-prod-qadb.lsst.codes-backups/squash-prod/
+aws s3 cp s3://jenkins-prod-qadb.lsst.codes-backups/squash-prod/<YYYYMMDD-HHMM>/squash-db-mariadb-qadb-<YYYYMMDD-HHMM>.gz .
+ 
+kubectl cp squash-db-mariadb-qadb-<YYYYMMDD-HHMM>.gz <squash-db pod>:/
+ 
 kubectl exec -it <squash-db pod> /bin/bash
+gzip -d squash-db-mariadb-qadb-<YYYYMMDD-HHMM>.gz 
  
-mysql -uroot -p<passwd> qadb < latest.sql
- 
-# The following is nedeed since the name of the django app changed 
-# from 'dashboard' to 'api' in the current implementation. 
- 
-mysql -uroot -p<passwd> qadb -e "RENAME TABLE dashboard_job to api_job, dashboard_measurement to api_measurement, dashboard_metric to api_metric, dashboard_versionedpackage to api_versionedpackage"
-
+mysql -uroot -p<passwd> qadb < squash-db-mariadb-qadb-<YYYYMMDD-HHMM>
 ```

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -11,7 +11,7 @@ spec:
     metadata:
       labels:
         app: squash
-        tier: backend
+        tier: database
     spec:
       containers:
       - image: mariadb:10.3

--- a/kubernetes/service.yaml
+++ b/kubernetes/service.yaml
@@ -4,12 +4,12 @@ metadata:
   name: squash-db
   labels:
     app: squash
-# target port 3306 on any pod with label tier: backend
+# target port 3306 on any pod with label 'tier: database'
 spec:
   ports:
     - port: 3306
   selector:
     app: squash
-    tier: backend
+    tier: database
   clusterIP: None
 

--- a/kubernetes/squash-db-backup.yaml
+++ b/kubernetes/squash-db-backup.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: squash-db-backup
+  namespace: squash-prod
+spec:
+  schedule: "@daily"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - args:
+            - --task=backup-mysql-exec
+            - --namespace=squash-prod
+            - --selector=app=squash,tier=database
+            - --container=mariadb
+            - --secret=squash-db-backup
+            image: lsstsqre/kube-backup:latest
+            name: squash-db-backup
+          restartPolicy: OnFailure


### PR DESCRIPTION
Used [kube-backup](https://github.com/lsst-sqre/kube-backup/pull/1) container utility and created a cronjob configuration to schedule `squash-db` backups for the squash production deployment.